### PR TITLE
Additional query arguments for performance

### DIFF
--- a/src/PostLockdown/PostLockdown.php
+++ b/src/PostLockdown/PostLockdown.php
@@ -189,6 +189,7 @@ class PostLockdown
             'update_post_term_cache' => false,
             'no_found_rows'          => true,
             'cache_results'          => false,
+            'ignore_sticky_posts'    => true,
         ];
 
         $args = wp_parse_args($args, $defaults);

--- a/src/PostLockdown/PostLockdown.php
+++ b/src/PostLockdown/PostLockdown.php
@@ -183,8 +183,12 @@ class PostLockdown
     public function get_posts($args = [])
     {
         $defaults = [
-            'post_type'   => $this->get_post_types(),
-            'post_status' => ['publish', 'pending', 'draft', 'future', 'private', 'inherit'],
+            'post_type'              => $this->get_post_types(),
+            'post_status'            => ['publish', 'pending', 'draft', 'future', 'private', 'inherit'],
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+            'no_found_rows'          => true,
+            'cache_results'          => false,
         ];
 
         $args = wp_parse_args($args, $defaults);


### PR DESCRIPTION
Adding `update_post_meta_cache => false`, `update_post_term_cache => false`, `cache_results => false`, and `no_found_rows => true` for slight better performance from `get_posts` function. Closes #4 

Also adding `ignore_sticky_posts => true` to avoid grabbing sticky posts in every query.